### PR TITLE
Add fdpass as allowed binary option.

### DIFF
--- a/lib/clam_scan/request.rb
+++ b/lib/clam_scan/request.rb
@@ -27,6 +27,7 @@ module ClamScan
       BOOLEAN_ARGS = %w(
         allmatch
         bell
+        fdpass
         infected
         leave_temps
         no_summary


### PR DESCRIPTION
--fdpass
    Pass the file descriptor permissions to clamd. This is useful if
clamd is running as a different user as it is faster than streaming the
file to clamd. Only available if connected to clamd via local(unix)
socket.

Or, in human language: --fdpass is needed if user clamav, as which clamd
runs, cannot access your files. Which is the case with e.g. rails and
scanning temporary uploads.